### PR TITLE
feature/frontend/クリックイベントデモ画面の実装

### DIFF
--- a/src/app/demos/config/interactions/click/features.ts
+++ b/src/app/demos/config/interactions/click/features.ts
@@ -1,0 +1,237 @@
+import { FeatureFile } from '../../types'
+
+export const clickFeatures: FeatureFile[] = [
+  {
+    id: 'click-events',
+    name: "クリックイベント",
+    description: "3Dオブジェクトのクリックイベントハンドリング",
+    files: ["src/app/demos/interactions/click/components/ClickInteraction.tsx"],
+    codeSections: [
+      {
+        title: "基本的なクリックイベント",
+        description: "onClickプロパティを使用した3Dオブジェクトのクリック検出",
+        fileName: "ClickInteraction.tsx",
+        code: `// クリックハンドラー
+const handleClick = (event: any) => {
+  event.stopPropagation()
+  setIsClicked(true)
+  setClickCount(prev => prev + 1)
+  setAnimationProgress(1) // アニメーション開始
+  
+  // 1秒後にクリック状態をリセット
+  setTimeout(() => {
+    setIsClicked(false)
+  }, 1000)
+}
+
+return (
+  <mesh 
+    onClick={handleClick}
+    onPointerEnter={() => setHovered(true)}
+    onPointerLeave={() => setHovered(false)}
+    onPointerOver={() => document.body.style.cursor = 'pointer'}
+    onPointerOut={() => document.body.style.cursor = 'auto'}
+  >
+    <boxGeometry args={[2, 2, 2]} />
+    <meshStandardMaterial 
+      color={isClicked ? '#00ff00' : hovered ? '#ffaa00' : '#ff6b6b'}
+      emissive={isClicked ? '#004400' : hovered ? '#442200' : '#000000'}
+    />
+  </mesh>
+)`,
+        highlights: [
+          {
+            id: "onclick",
+            startLine: 14,
+            endLine: 14,
+            startColumn: 4,
+            endColumn: 25,
+            tooltip: {
+              title: "onClick",
+              description: "3Dオブジェクトがクリックされた時に実行される関数を指定します。React Three Fiberでは通常のReactと同様にonClickイベントを使用できます。",
+              documentationUrl: "https://threejs.org/docs/#api/en/core/Raycaster",
+              r3fDocumentationUrl: "https://r3f.docs.pmnd.rs/getting-started/events"
+            }
+          },
+          {
+            id: "pointer-events",
+            startLine: 15,
+            endLine: 18,
+            startColumn: 4,
+            endColumn: 60,
+            tooltip: {
+              title: "ポインターイベント",
+              description: "onPointerEnter/Leaveでホバー状態を検出し、onPointerOver/Outでカーソルスタイルを変更できます。これによりユーザーにインタラクティブな要素であることを示せます。",
+              documentationUrl: "https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events",
+              r3fDocumentationUrl: "https://r3f.docs.pmnd.rs/getting-started/events"
+            }
+          },
+          {
+            id: "stop-propagation",
+            startLine: 3,
+            endLine: 3,
+            startColumn: 2,
+            endColumn: 25,
+            tooltip: {
+              title: "stopPropagation",
+              description: "イベントの伝播を停止します。複数のオブジェクトが重なっている場合に、背景のオブジェクトにもイベントが伝わることを防ぎます。",
+              documentationUrl: "https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation",
+              r3fDocumentationUrl: "https://r3f.docs.pmnd.rs/getting-started/events"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'visual-feedback',
+    name: "ビジュアルフィードバック",
+    description: "クリック時の色変更とアニメーション効果",
+    files: ["src/app/demos/interactions/click/components/ClickInteraction.tsx"],
+    codeSections: [
+      {
+        title: "状態に応じた色変更",
+        description: "クリック状態とホバー状態に応じてマテリアルの色を動的に変更",
+        fileName: "ClickInteraction.tsx",
+        code: `const [isClicked, setIsClicked] = useState(false)
+const [hovered, setHovered] = useState(false)
+
+// マテリアルの色を状態に応じて変更
+<meshStandardMaterial 
+  color={isClicked ? '#00ff00' : hovered ? '#ffaa00' : '#ff6b6b'}
+  emissive={isClicked ? '#004400' : hovered ? '#442200' : '#000000'}
+/>
+
+// アニメーションフレームでのスケール変更
+useFrame((state, delta) => {
+  if (meshRef.current) {
+    // クリック時のアニメーション
+    if (animationProgress > 0) {
+      // スケールアニメーション（バウンス効果）
+      const bounce = Math.sin(animationProgress * Math.PI * 4) * 0.2 + 1
+      meshRef.current.scale.setScalar(bounce)
+      
+      // アニメーション進行
+      setAnimationProgress(prev => Math.max(0, prev - delta * 2))
+    }
+  }
+})`,
+        highlights: [
+          {
+            id: "conditional-color",
+            startLine: 5,
+            endLine: 7,
+            startColumn: 2,
+            endColumn: 3,
+            tooltip: {
+              title: "条件付き色変更",
+              description: "三項演算子を使用して状態に応じて色を動的に変更します。colorは基本色、emissiveは発光色を設定し、よりリッチな視覚効果を実現できます。",
+              documentationUrl: "https://threejs.org/docs/#api/en/materials/MeshStandardMaterial",
+              r3fDocumentationUrl: "https://r3f.docs.pmnd.rs/api/objects#materials"
+            }
+          },
+          {
+            id: "bounce-animation",
+            startLine: 15,
+            endLine: 16,
+            startColumn: 6,
+            endColumn: 50,
+            tooltip: {
+              title: "バウンスアニメーション",
+              description: "Math.sin関数を使用してバウンス効果を作成します。animationProgressが1から0に減少する間、オブジェクトが弾むようなスケール変化を実現します。",
+              documentationUrl: "https://threejs.org/docs/#api/en/core/Object3D.scale",
+              r3fDocumentationUrl: "https://r3f.docs.pmnd.rs/api/hooks#useframe"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'multiple-interactions',
+    name: "複数オブジェクトのインタラクション",
+    description: "複数の3Dオブジェクトそれぞれに異なるクリック動作を実装",
+    files: ["src/app/demos/interactions/click/components/ClickInteraction.tsx"],
+    codeSections: [
+      {
+        title: "再利用可能なインタラクティブコンポーネント",
+        description: "独立したクリック動作を持つ球体コンポーネント",
+        fileName: "ClickInteraction.tsx",
+        code: `function InteractiveSphere({ position }: { position: [number, number, number] }) {
+  const sphereRef = useRef<Mesh>(null)
+  const [clicked, setClicked] = useState(false)
+  const [color, setColor] = useState('#6b6bff')
+
+  const handleSphereClick = (event: any) => {
+    event.stopPropagation()
+    setClicked(true)
+    
+    // ランダムな色に変更
+    const colors = ['#ff6b6b', '#6bff6b', '#6b6bff', '#ffff6b', '#ff6bff', '#6bffff']
+    const randomColor = colors[Math.floor(Math.random() * colors.length)]
+    setColor(randomColor)
+    
+    setTimeout(() => setClicked(false), 500)
+  }
+
+  return (
+    <mesh 
+      ref={sphereRef}
+      position={position}
+      onClick={handleSphereClick}
+      onPointerOver={() => document.body.style.cursor = 'pointer'}
+      onPointerOut={() => document.body.style.cursor = 'auto'}
+    >
+      <sphereGeometry args={[1, 16, 16]} />
+      <meshStandardMaterial 
+        color={color}
+        emissive={clicked ? new THREE.Color(color).multiplyScalar(0.2) : '#000000'}
+      />
+    </mesh>
+  )
+}`,
+        highlights: [
+          {
+            id: "component-props",
+            startLine: 1,
+            endLine: 1,
+            startColumn: 1,
+            endColumn: 80,
+            tooltip: {
+              title: "コンポーネントのプロパティ",
+              description: "position propsを受け取ることで、同じコンポーネントを異なる位置に配置できます。これにより再利用可能なインタラクティブコンポーネントを作成できます。",
+              documentationUrl: "https://react.dev/learn/passing-props-to-a-component",
+              r3fDocumentationUrl: "https://r3f.docs.pmnd.rs/getting-started/your-first-scene"
+            }
+          },
+          {
+            id: "random-color",
+            startLine: 9,
+            endLine: 11,
+            startColumn: 4,
+            endColumn: 25,
+            tooltip: {
+              title: "ランダム色変更",
+              description: "配列から Math.floor(Math.random()) を使用してランダムに色を選択します。クリックするたびに異なる色に変化し、インタラクティブな体験を提供します。",
+              documentationUrl: "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random",
+              r3fDocumentationUrl: "https://r3f.docs.pmnd.rs/api/objects#materials"
+            }
+          },
+          {
+            id: "color-multiply",
+            startLine: 26,
+            endLine: 26,
+            startColumn: 18,
+            endColumn: 70,
+            tooltip: {
+              title: "色の計算",
+              description: "THREE.Color.multiplyScalar()を使用して色の明度を調整します。クリック時に発光色として元の色を暗くした色を使用し、より自然な発光効果を実現します。",
+              documentationUrl: "https://threejs.org/docs/#api/en/math/Color.multiplyScalar",
+              r3fDocumentationUrl: "https://r3f.docs.pmnd.rs/api/objects#materials"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/app/demos/config/interactions/click/file-contents.ts
+++ b/src/app/demos/config/interactions/click/file-contents.ts
@@ -1,0 +1,346 @@
+export const clickFileContents: Record<string, string> = {
+  'src/app/demos/interactions/click/page.tsx': `'use client'
+
+import { DemoLayout } from '../../components/common'
+import { ClickInteraction } from './components/ClickInteraction'
+import { clickFiles, clickFeatures, clickFileContents } from '../../config/interactions/click'
+
+export default function ClickDemo() {
+  return (
+    <DemoLayout 
+      title="Click Interaction Demo" 
+      description="3Dオブジェクトのクリックイベントを使ったインタラクションのデモ"
+      files={clickFiles}
+      features={clickFeatures}
+      fileContents={clickFileContents}
+    >
+      <ClickInteraction />
+    </DemoLayout>
+  )
+}`,
+
+  'src/app/demos/interactions/click/components/ClickInteraction.tsx': `'use client'
+
+import { useRef, useState } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { Text } from '@react-three/drei'
+import { Mesh } from 'three'
+import * as THREE from 'three'
+
+export function ClickInteraction() {
+  const meshRef = useRef<Mesh>(null)
+  const [isClicked, setIsClicked] = useState(false)
+  const [clickCount, setClickCount] = useState(0)
+  const [hovered, setHovered] = useState(false)
+
+  // クリック時のアニメーション用の状態
+  const [animationProgress, setAnimationProgress] = useState(0)
+
+  // クリックハンドラー
+  const handleClick = (event: any) => {
+    event.stopPropagation()
+    setIsClicked(true)
+    setClickCount(prev => prev + 1)
+    setAnimationProgress(1) // アニメーション開始
+    
+    // 1秒後にクリック状態をリセット
+    setTimeout(() => {
+      setIsClicked(false)
+    }, 1000)
+  }
+
+  // アニメーションフレーム
+  useFrame((state, delta) => {
+    if (meshRef.current) {
+      // 通常の回転
+      meshRef.current.rotation.y += delta * 0.5
+      
+      // クリック時のアニメーション
+      if (animationProgress > 0) {
+        // スケールアニメーション（バウンス効果）
+        const bounce = Math.sin(animationProgress * Math.PI * 4) * 0.2 + 1
+        meshRef.current.scale.setScalar(bounce)
+        
+        // アニメーション進行
+        setAnimationProgress(prev => Math.max(0, prev - delta * 2))
+      } else {
+        // 通常のスケールに戻す
+        meshRef.current.scale.setScalar(1)
+      }
+      
+      // ホバー時の浮遊効果
+      if (hovered) {
+        meshRef.current.position.y = Math.sin(state.clock.elapsedTime * 3) * 0.1 + 0.2
+      } else {
+        meshRef.current.position.y = 0
+      }
+    }
+  })
+
+  return (
+    <group>
+      {/* クリック可能な立方体 */}
+      <mesh 
+        ref={meshRef} 
+        position={[0, 0, 0]} 
+        castShadow 
+        receiveShadow
+        onClick={handleClick}
+        onPointerEnter={() => setHovered(true)}
+        onPointerLeave={() => setHovered(false)}
+        // カーソルスタイルの変更
+        onPointerOver={() => document.body.style.cursor = 'pointer'}
+        onPointerOut={() => document.body.style.cursor = 'auto'}
+      >
+        <boxGeometry args={[2, 2, 2]} />
+        <meshStandardMaterial 
+          color={isClicked ? '#00ff00' : hovered ? '#ffaa00' : '#ff6b6b'}
+          emissive={isClicked ? '#004400' : hovered ? '#442200' : '#000000'}
+        />
+      </mesh>
+      
+      {/* クリック回数表示 */}
+      <Text 
+        position={[0, -2.5, 0]} 
+        fontSize={0.5} 
+        color="white" 
+        anchorX="center"
+      >
+        Clicks: {clickCount}
+      </Text>
+      
+      {/* 操作説明 */}
+      <Text 
+        position={[0, -3.2, 0]} 
+        fontSize={0.3} 
+        color="gray" 
+        anchorX="center"
+      >
+        {hovered ? 'Click me!' : 'Hover to interact'}
+      </Text>
+      
+      {/* 追加のインタラクティブオブジェクト */}
+      <InteractiveSphere position={[-3, 0, 0]} />
+      <InteractiveSphere position={[3, 0, 0]} />
+    </group>
+  )
+}
+
+// 追加のインタラクティブ球体コンポーネント
+function InteractiveSphere({ position }: { position: [number, number, number] }) {
+  const sphereRef = useRef<Mesh>(null)
+  const [clicked, setClicked] = useState(false)
+  const [color, setColor] = useState('#6b6bff')
+
+  const handleSphereClick = (event: any) => {
+    event.stopPropagation()
+    setClicked(true)
+    
+    // ランダムな色に変更
+    const colors = ['#ff6b6b', '#6bff6b', '#6b6bff', '#ffff6b', '#ff6bff', '#6bffff']
+    const randomColor = colors[Math.floor(Math.random() * colors.length)]
+    setColor(randomColor)
+    
+    setTimeout(() => setClicked(false), 500)
+  }
+
+  useFrame((state, delta) => {
+    if (sphereRef.current) {
+      sphereRef.current.rotation.x += delta
+      sphereRef.current.rotation.z += delta * 0.5
+      
+      if (clicked) {
+        const scale = 1 + Math.sin(state.clock.elapsedTime * 10) * 0.1
+        sphereRef.current.scale.setScalar(scale)
+      } else {
+        sphereRef.current.scale.setScalar(1)
+      }
+    }
+  })
+
+  return (
+    <mesh 
+      ref={sphereRef}
+      position={position}
+      onClick={handleSphereClick}
+      onPointerOver={() => document.body.style.cursor = 'pointer'}
+      onPointerOut={() => document.body.style.cursor = 'auto'}
+      castShadow
+      receiveShadow
+    >
+      <sphereGeometry args={[1, 16, 16]} />
+      <meshStandardMaterial 
+        color={color}
+        emissive={clicked ? new THREE.Color(color).multiplyScalar(0.2) : '#000000'}
+      />
+    </mesh>
+  )
+}`,
+
+  'src/app/demos/components/common/DemoLayout.tsx': `'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Canvas } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
+import { Lighting } from './Lighting'
+import { FileExplorer, FeatureSelector, CodeViewer } from '../file-system'
+import { FileNode, FeatureFile } from '../../config/types'
+
+interface DemoLayoutProps {
+  title: string
+  description: string
+  files: FileNode[]
+  features: FeatureFile[]
+  fileContents: Record<string, string>
+  children: React.ReactNode
+}
+
+export function DemoLayout({ 
+  title, 
+  description, 
+  files, 
+  features, 
+  fileContents, 
+  children 
+}: DemoLayoutProps) {
+  const [selectedFeature, setSelectedFeature] = useState<FeatureFile | null>(null)
+  const [selectedFile, setSelectedFile] = useState<string | null>(null)
+
+  // ファイルが選択された時の処理
+  const handleFileSelect = (fileName: string) => {
+    setSelectedFile(fileName)
+    
+    // 選択されたファイルに関連する機能を検索
+    const relatedFeature = features.find(feature => 
+      feature.files.some(file => file.includes(fileName) || fileName.includes(file))
+    )
+    
+    if (relatedFeature) {
+      setSelectedFeature(relatedFeature)
+    }
+  }
+
+  // 機能が選択された時の処理
+  const handleFeatureSelect = (feature: FeatureFile) => {
+    setSelectedFeature(feature)
+    // 機能の最初のファイルを選択
+    if (feature.files.length > 0) {
+      setSelectedFile(feature.files[0])
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <div className="bg-gray-900 min-h-full">
+        <div className="container mx-auto px-4 py-8">
+          {/* ナビゲーション */}
+          <div className="mb-6">
+            <Link 
+              href="/demos" 
+              className="inline-flex items-center text-blue-400 hover:text-blue-300 transition-colors duration-200 text-sm"
+            >
+              <svg className="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clipRule="evenodd" />
+              </svg>
+              デモ一覧に戻る
+            </Link>
+          </div>
+
+          <div className="mb-8">
+            <h1 className="text-3xl font-bold mb-2">{title}</h1>
+            <p className="text-gray-300">{description}</p>
+          </div>
+          
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 min-h-[calc(100vh-200px)]">
+            {/* 3D Canvas */}
+            <div className="bg-gray-800 rounded-lg overflow-hidden min-h-[500px]">
+              <Canvas
+                camera={{ 
+                  position: [3, 3, 3],  // カメラの初期位置
+                  fov: 60               // 視野角（Field of View）
+                }}
+                shadows                 // 影の描画を有効化
+                className="w-full h-full"
+              >
+                <Lighting />
+                {children}
+                
+                <OrbitControls 
+                  enablePan={true} 
+                  enableZoom={true} 
+                  enableRotate={true} 
+                />
+                
+                <gridHelper args={[10, 10]} />
+              </Canvas>
+            </div>
+            
+            {/* Code Panel */}
+            <div className="bg-gray-800 rounded-lg p-4 flex flex-col min-h-[500px]">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                <FileExplorer 
+                  files={files} 
+                  selectedFile={selectedFile}
+                  onFileSelect={handleFileSelect}
+                />
+                <FeatureSelector 
+                  features={features} 
+                  selectedFeature={selectedFeature}
+                  onFeatureSelect={handleFeatureSelect}
+                />
+              </div>
+              <div className="flex-1">
+                <CodeViewer 
+                  features={features} 
+                  fileContents={fileContents} 
+                  selectedFeature={selectedFeature}
+                  selectedFile={selectedFile}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}`,
+
+  'src/app/demos/components/common/Lighting.tsx': `'use client'
+
+export function Lighting() {
+  return (
+    <>
+      {/* 
+        ambientLight: 環境光
+        - 全体を均等に照らす
+        - 影のコントラストを調整
+      */}
+      <ambientLight intensity={0.4} />
+      
+      {/* 
+        directionalLight: 指向性ライト（太陽光のような平行光）
+        - 影を生成する主要光源
+        - position: ライトの方向を決定
+      */}
+      <directionalLight 
+        position={[10, 10, 5]} 
+        intensity={1}
+        castShadow
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+      />
+      
+      {/* 
+        pointLight: ポイントライト（電球のような点光源）
+        - 色付きの補助照明として使用
+      */}
+      <pointLight position={[-10, -10, -10]} color="#ff0000" intensity={0.3} />
+      <pointLight position={[10, -10, -10]} color="#0000ff" intensity={0.3} />
+    </>
+  )
+}`,
+
+  'src/app/demos/components/common/index.ts': `export { DemoLayout } from './DemoLayout'
+export { Lighting } from './Lighting'`
+}

--- a/src/app/demos/config/interactions/click/files.ts
+++ b/src/app/demos/config/interactions/click/files.ts
@@ -1,0 +1,57 @@
+import { FileNode } from '../../types'
+
+export const clickFiles: FileNode[] = [
+  {
+    name: 'src',
+    type: 'folder',
+    children: [
+      {
+        name: 'app',
+        type: 'folder',
+        children: [
+          {
+            name: 'demos',
+            type: 'folder',
+            children: [
+              {
+                name: 'interactions',
+                type: 'folder',
+                children: [
+                  {
+                    name: 'click',
+                    type: 'folder',
+                    children: [
+                      { name: 'page.tsx', type: 'file' },
+                      {
+                        name: 'components',
+                        type: 'folder',
+                        children: [
+                          { name: 'ClickInteraction.tsx', type: 'file' }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                name: 'components',
+                type: 'folder',
+                children: [
+                  {
+                    name: 'common',
+                    type: 'folder',
+                    children: [
+                      { name: 'DemoLayout.tsx', type: 'file' },
+                      { name: 'Lighting.tsx', type: 'file' },
+                      { name: 'index.ts', type: 'file' }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/app/demos/config/interactions/click/index.ts
+++ b/src/app/demos/config/interactions/click/index.ts
@@ -1,0 +1,3 @@
+export { clickFiles } from './files'
+export { clickFeatures } from './features'
+export { clickFileContents } from './file-contents'

--- a/src/app/demos/interactions/click/components/ClickInteraction.tsx
+++ b/src/app/demos/interactions/click/components/ClickInteraction.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { Text } from '@react-three/drei'
+import { Mesh } from 'three'
+import * as THREE from 'three'
+
+export function ClickInteraction() {
+  const meshRef = useRef<Mesh>(null)
+  const [isClicked, setIsClicked] = useState(false)
+  const [clickCount, setClickCount] = useState(0)
+  const [hovered, setHovered] = useState(false)
+
+  // クリック時のアニメーション用の状態
+  const [animationProgress, setAnimationProgress] = useState(0)
+
+  // クリックハンドラー
+  const handleClick = (event: any) => {
+    event.stopPropagation()
+    setIsClicked(true)
+    setClickCount(prev => prev + 1)
+    setAnimationProgress(1) // アニメーション開始
+    
+    // 1秒後にクリック状態をリセット
+    setTimeout(() => {
+      setIsClicked(false)
+    }, 1000)
+  }
+
+  // アニメーションフレーム
+  useFrame((state, delta) => {
+    if (meshRef.current) {
+      // 通常の回転
+      meshRef.current.rotation.y += delta * 0.5
+      
+      // クリック時のアニメーション
+      if (animationProgress > 0) {
+        // スケールアニメーション（バウンス効果）
+        const bounce = Math.sin(animationProgress * Math.PI * 4) * 0.2 + 1
+        meshRef.current.scale.setScalar(bounce)
+        
+        // アニメーション進行
+        setAnimationProgress(prev => Math.max(0, prev - delta * 2))
+      } else {
+        // 通常のスケールに戻す
+        meshRef.current.scale.setScalar(1)
+      }
+      
+      // ホバー時の浮遊効果
+      if (hovered) {
+        meshRef.current.position.y = Math.sin(state.clock.elapsedTime * 3) * 0.1 + 0.2
+      } else {
+        meshRef.current.position.y = 0
+      }
+    }
+  })
+
+  return (
+    <group>
+      {/* クリック可能な立方体 */}
+      <mesh 
+        ref={meshRef} 
+        position={[0, 0, 0]} 
+        castShadow 
+        receiveShadow
+        onClick={handleClick}
+        onPointerEnter={() => setHovered(true)}
+        onPointerLeave={() => setHovered(false)}
+        // カーソルスタイルの変更
+        onPointerOver={() => document.body.style.cursor = 'pointer'}
+        onPointerOut={() => document.body.style.cursor = 'auto'}
+      >
+        <boxGeometry args={[2, 2, 2]} />
+        <meshStandardMaterial 
+          color={isClicked ? '#00ff00' : hovered ? '#ffaa00' : '#ff6b6b'}
+          emissive={isClicked ? '#004400' : hovered ? '#442200' : '#000000'}
+        />
+      </mesh>
+      
+      {/* クリック回数表示 */}
+      <Text 
+        position={[0, -2.5, 0]} 
+        fontSize={0.5} 
+        color="white" 
+        anchorX="center"
+      >
+        Clicks: {clickCount}
+      </Text>
+      
+      {/* 操作説明 */}
+      <Text 
+        position={[0, -3.2, 0]} 
+        fontSize={0.3} 
+        color="gray" 
+        anchorX="center"
+      >
+        {hovered ? 'Click me!' : 'Hover to interact'}
+      </Text>
+      
+      {/* 追加のインタラクティブオブジェクト */}
+      <InteractiveSphere position={[-3, 0, 0]} />
+      <InteractiveSphere position={[3, 0, 0]} />
+    </group>
+  )
+}
+
+// 追加のインタラクティブ球体コンポーネント
+function InteractiveSphere({ position }: { position: [number, number, number] }) {
+  const sphereRef = useRef<Mesh>(null)
+  const [clicked, setClicked] = useState(false)
+  const [color, setColor] = useState('#6b6bff')
+
+  const handleSphereClick = (event: any) => {
+    event.stopPropagation()
+    setClicked(true)
+    
+    // ランダムな色に変更
+    const colors = ['#ff6b6b', '#6bff6b', '#6b6bff', '#ffff6b', '#ff6bff', '#6bffff']
+    const randomColor = colors[Math.floor(Math.random() * colors.length)]
+    setColor(randomColor)
+    
+    setTimeout(() => setClicked(false), 500)
+  }
+
+  useFrame((state, delta) => {
+    if (sphereRef.current) {
+      sphereRef.current.rotation.x += delta
+      sphereRef.current.rotation.z += delta * 0.5
+      
+      if (clicked) {
+        const scale = 1 + Math.sin(state.clock.elapsedTime * 10) * 0.1
+        sphereRef.current.scale.setScalar(scale)
+      } else {
+        sphereRef.current.scale.setScalar(1)
+      }
+    }
+  })
+
+  return (
+    <mesh 
+      ref={sphereRef}
+      position={position}
+      onClick={handleSphereClick}
+      onPointerOver={() => document.body.style.cursor = 'pointer'}
+      onPointerOut={() => document.body.style.cursor = 'auto'}
+      castShadow
+      receiveShadow
+    >
+      <sphereGeometry args={[1, 16, 16]} />
+      <meshStandardMaterial 
+        color={color}
+        emissive={clicked ? new THREE.Color(color).multiplyScalar(0.2) : '#000000'}
+      />
+    </mesh>
+  )
+}

--- a/src/app/demos/interactions/click/page.tsx
+++ b/src/app/demos/interactions/click/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { DemoLayout } from '../../components/common'
+import { ClickInteraction } from './components/ClickInteraction'
+import { clickFiles, clickFeatures, clickFileContents } from '../../config/interactions/click'
+
+export default function ClickDemo() {
+  return (
+    <DemoLayout 
+      title="Click Interaction Demo" 
+      description="3Dオブジェクトのクリックイベントを使ったインタラクションのデモ"
+      files={clickFiles}
+      features={clickFeatures}
+      fileContents={clickFileContents}
+    >
+      <ClickInteraction />
+    </DemoLayout>
+  )
+}

--- a/src/app/demos/interactions/page.tsx
+++ b/src/app/demos/interactions/page.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import Link from 'next/link'
+
+// インタラクションデモの定義
+const interactionDemos = [
+  {
+    id: 'click',
+    title: 'Click Events',
+    japaneseTitle: 'クリックイベント',
+    description: 'オブジェクトのクリック検出と反応'
+  },
+  {
+    id: 'hover-effects',
+    title: 'Hover Effects',
+    japaneseTitle: 'ホバーエフェクト',
+    description: 'マウスオーバー時の色変化やスケール変更'
+  },
+  {
+    id: 'drag-drop',
+    title: 'Drag & Drop',
+    japaneseTitle: 'ドラッグ&ドロップ',
+    description: 'オブジェクトのドラッグによる移動操作'
+  },
+  {
+    id: 'raycasting',
+    title: 'Raycasting',
+    japaneseTitle: 'レイキャスティング',
+    description: 'マウス位置からのレイキャストによる詳細な当たり判定'
+  },
+  {
+    id: 'keyboard-controls',
+    title: 'Keyboard Controls',
+    japaneseTitle: 'キーボード操作',
+    description: 'キーボード入力によるオブジェクト制御'
+  },
+  {
+    id: 'camera-controls',
+    title: 'Camera Controls',
+    japaneseTitle: 'カメラ操作',
+    description: 'OrbitControlsを使ったカメラの回転・ズーム操作'
+  },
+  {
+    id: 'multi-selection',
+    title: 'Multi Selection',
+    japaneseTitle: '複数選択',
+    description: '複数オブジェクトの選択と一括操作'
+  },
+  {
+    id: 'gesture-controls',
+    title: 'Gesture Controls',
+    japaneseTitle: 'ジェスチャー操作',
+    description: 'タッチデバイスでのピンチ・スワイプ操作'
+  }
+]
+
+// 各インタラクションのカードコンポーネント
+function InteractionCard({ demo }: { demo: typeof interactionDemos[0] }) {
+  return (
+    <Link href={`/demos/interactions/${demo.id}`}>
+      <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6 transition-all duration-300 hover:bg-white/20 transform hover:scale-105">
+        <h3 className="text-xl font-bold text-white mb-1">
+          {demo.title} <span className="text-gray-300">({demo.japaneseTitle})</span>
+        </h3>
+        <p className="text-gray-300 text-sm">
+          {demo.description}
+        </p>
+      </div>
+    </Link>
+  )
+}
+
+export default function InteractionsPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-green-900 via-teal-900 to-blue-900">
+      <div className="container mx-auto px-4 py-16">
+        {/* ヘッダー */}
+        <div className="text-center mb-12">
+          <Link href="/demos" className="inline-block mb-6 text-blue-300 hover:text-blue-200">
+            ← デモ一覧に戻る
+          </Link>
+          <h1 className="text-5xl font-bold text-white mb-4">Interaction Demos</h1>
+          <p className="text-xl text-gray-300 max-w-2xl mx-auto">
+            React Three Fiberを使った様々なインタラクション技法のデモ集
+          </p>
+        </div>
+
+        {/* インタラクションデモグリッド */}
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
+          {interactionDemos.map((demo) => (
+            <InteractionCard key={demo.id} demo={demo} />
+          ))}
+        </div>
+
+        {/* 学習のヒント */}
+        <div className="mt-16 max-w-4xl mx-auto">
+          <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+            <h3 className="text-lg font-bold text-white mb-4">💡 インタラクション学習のポイント</h3>
+            <div className="grid md:grid-cols-2 gap-4 text-sm text-gray-300">
+              <div>
+                <h4 className="font-medium text-white mb-2">基本概念</h4>
+                <ul className="space-y-1">
+                  <li>• Raycastingの仕組み</li>
+                  <li>• イベントハンドリング</li>
+                  <li>• 状態管理</li>
+                </ul>
+              </div>
+              <div>
+                <h4 className="font-medium text-white mb-2">実装のコツ</h4>
+                <ul className="space-y-1">
+                  <li>• パフォーマンス最適化</li>
+                  <li>• ユーザビリティ向上</li>
+                  <li>• レスポンシブ対応</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/demos/page.tsx
+++ b/src/app/demos/page.tsx
@@ -38,7 +38,7 @@ const demos = [
     title: 'Interactions',
     description: 'マウス・キーボードインタラクション',
     icon: '🖱️',
-    status: 'planned',
+    status: 'completed',
     features: ['Raycasting', 'Click Events', 'Hover Effects', 'Drag & Drop']
   },
   {


### PR DESCRIPTION
## 概要
### クリックイベントデモ画面の実装
React Three Fiber（R3F）を使用した3Dオブジェクトのクリックイベント処理のデモ画面を実装。
ユーザーがR3Fでのクリックイベントの実装方法を学べるよう、視覚的なデモと解説を提供。

## 変更内容
- クリックイベントデモページの作成
- クリック可能な3Dオブジェクトの実装
- クリック時のアニメーションと視覚的フィードバック
- ホバー状態の視覚的表現
- クリック回数のカウンターと表示
- インタラクション一覧ページの作成
- 設定ファイルの追加（features, files, file-contents）

## 実装したファイル
- src/app/demos/interactions/click/page.tsx
- src/app/demos/interactions/click/components/ClickInteraction.tsx
- src/app/demos/config/interactions/click/features.ts
- src/app/demos/config/interactions/click/file-contents.ts
- src/app/demos/config/interactions/click/files.ts
- src/app/demos/config/interactions/click/index.ts
- src/app/demos/interactions/page.tsx

## 主な機能
- 3Dオブジェクトのクリック検出（onClick）
- ホバー状態の検出（onPointerEnter, onPointerLeave）
- カーソルスタイルの動的変更（onPointerOver, onPointerOut）
- クリック時のバウンスアニメーション
- ホバー時の浮遊エフェクト
- クリック回数の表示
- 操作説明テキスト

## 技術的詳細
- React Hooksを使用した状態管理（useState, useRef）
- useFrameフックを使用したアニメーション処理
- @react-three/dreiのTextコンポーネントを使用したテキスト表示
- イベント伝播の制御（stopPropagation）
- 動的な色とエミッシブ値の変更
- アニメーション進行状態の管理

## スクリーンショット
![github-pr-feature:frontend:interaction-demo-click-event](https://github.com/user-attachments/assets/5a9141d1-e9b4-4feb-b20e-d887ffe538b6)


## テスト方法
1. デモページにアクセス（/demos/interactions/click）
2. 中央の立方体をクリックして反応を確認
3. 立方体にマウスを乗せてホバー効果を確認
4. 左右の球体をクリックして色の変化を確認

## 関連issue
Closes #20 