### PR TITLE
feature/frontend/DnDによるスケール変更デモ画面の実装

### DIFF
--- a/src/app/demos/components/common/DemoLayoutWithControls.tsx
+++ b/src/app/demos/components/common/DemoLayoutWithControls.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useState, createContext, useContext } from 'react'
+import Link from 'next/link'
+import { Canvas } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
+import { Lighting } from './Lighting'
+import { FileExplorer, FeatureSelector, CodeViewer } from '../file-system'
+import { FileNode, FeatureFile } from '../../config/types'
+
+// カメラ操作の制御用コンテキスト
+const CameraControlContext = createContext<{
+  enableControls: boolean
+  setEnableControls: (enable: boolean) => void
+}>({
+  enableControls: true,
+  setEnableControls: () => {}
+})
+
+export const useCameraControl = () => useContext(CameraControlContext)
+
+interface DemoLayoutWithControlsProps {
+  title: string
+  description: string
+  files: FileNode[]
+  features: FeatureFile[]
+  fileContents: Record<string, string>
+  children: React.ReactNode
+  backLink?: string
+  backLinkText?: string
+}
+
+export function DemoLayoutWithControls({ 
+  title, 
+  description, 
+  files, 
+  features, 
+  fileContents, 
+  children,
+  backLink = "/demos",
+  backLinkText = "デモ一覧に戻る"
+}: DemoLayoutWithControlsProps) {
+  const [selectedFeature, setSelectedFeature] = useState<FeatureFile | null>(null)
+  const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  const [enableControls, setEnableControls] = useState(true)
+
+  // ファイルが選択された時の処理
+  const handleFileSelect = (fileName: string) => {
+    setSelectedFile(fileName)
+    
+    // 選択されたファイルに関連する機能を検索
+    const relatedFeature = features.find(feature => 
+      feature.files.some(file => file.includes(fileName) || fileName.includes(file))
+    )
+    
+    if (relatedFeature) {
+      setSelectedFeature(relatedFeature)
+    }
+  }
+
+  // 機能が選択された時の処理
+  const handleFeatureSelect = (feature: FeatureFile) => {
+    setSelectedFeature(feature)
+    // 機能の最初のファイルを選択
+    if (feature.files.length > 0) {
+      setSelectedFile(feature.files[0])
+    }
+  }
+
+  return (
+    <CameraControlContext.Provider value={{ enableControls, setEnableControls }}>
+      <div className="min-h-screen bg-gray-900 text-white">
+        <div className="bg-gray-900 min-h-full">
+          <div className="container mx-auto px-4 py-8">
+            {/* ナビゲーション */}
+            <div className="mb-6">
+              <Link 
+                href={backLink}
+                className="inline-flex items-center text-blue-400 hover:text-blue-300 transition-colors duration-200 text-sm"
+              >
+                <svg className="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+                {backLinkText}
+              </Link>
+            </div>
+
+            <div className="mb-8">
+              <h1 className="text-3xl font-bold mb-2">{title}</h1>
+              <p className="text-gray-300">{description}</p>
+            </div>
+            
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 min-h-[calc(100vh-200px)]">
+              {/* 3D Canvas */}
+              <div className="bg-gray-800 rounded-lg overflow-hidden min-h-[500px]">
+                <Canvas
+                  camera={{ 
+                    position: [3, 3, 3],
+                    fov: 60
+                  }}
+                  shadows
+                  className="w-full h-full"
+                >
+                  <Lighting />
+                  {children}
+                  
+                  <OrbitControls 
+                    enabled={enableControls}
+                    enablePan={enableControls} 
+                    enableZoom={enableControls} 
+                    enableRotate={enableControls} 
+                  />
+                  
+                  <gridHelper args={[10, 10]} />
+                </Canvas>
+              </div>
+              
+              {/* Code Panel */}
+              <div className="bg-gray-800 rounded-lg p-4 flex flex-col min-h-[500px]">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                  <FileExplorer 
+                    files={files} 
+                    selectedFile={selectedFile}
+                    onFileSelect={handleFileSelect}
+                  />
+                  <FeatureSelector 
+                    features={features} 
+                    selectedFeature={selectedFeature}
+                    onFeatureSelect={handleFeatureSelect}
+                  />
+                </div>
+                <div className="flex-1">
+                  <CodeViewer 
+                    features={features} 
+                    fileContents={fileContents} 
+                    selectedFeature={selectedFeature}
+                    selectedFile={selectedFile}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </CameraControlContext.Provider>
+  )
+}

--- a/src/app/demos/components/common/index.ts
+++ b/src/app/demos/components/common/index.ts
@@ -1,2 +1,3 @@
 export { DemoLayout } from './DemoLayout'
+export { DemoLayoutWithControls, useCameraControl } from './DemoLayoutWithControls'
 export { Lighting } from './Lighting'

--- a/src/app/demos/config/interactions/dnd-scale/features.ts
+++ b/src/app/demos/config/interactions/dnd-scale/features.ts
@@ -1,0 +1,273 @@
+import { FeatureFile } from '../../types'
+
+export const dndScaleFeatures: FeatureFile[] = [
+  {
+    id: 'drag-scale-interaction',
+    name: "ドラッグ&ドロップによる寸法変更",
+    description: "マウスドラッグによるオブジェクトのスケール変更機能",
+    files: ["src/app/demos/interactions/dnd-scale/components/DndScaleInteractionWithControls.tsx"],
+    codeSections: [
+      {
+        title: "ドラッグ状態管理",
+        description: "ドラッグ操作の状態を管理するためのstate設計",
+        fileName: "DndScaleInteractionWithControls.tsx",
+        code: `interface DragState {
+  isDragging: boolean
+  startPosition: Vector3
+  startScale: Vector3
+  object: Mesh | null
+}
+
+const [dragState, setDragState] = useState<DragState>({
+  isDragging: false,
+  startPosition: new Vector3(),
+  startScale: new Vector3(),
+  object: null
+})
+
+// ドラッグ状態が変わったときにカメラ操作を制御
+useEffect(() => {
+  setEnableControls(!dragState.isDragging)
+}, [dragState.isDragging, setEnableControls])`,
+        highlights: [
+          {
+            id: "drag-state",
+            startLine: 1,
+            endLine: 6,
+            startColumn: 1,
+            endColumn: 1,
+            tooltip: {
+              title: "DragState インターフェース",
+              description: "ドラッグ操作に必要な状態を定義します。isDragging（ドラッグ中かどうか）、startPosition（開始位置）、startScale（開始時のスケール）、object（対象オブジェクト）を管理します。",
+              documentationUrl: "https://threejs.org/docs/#api/en/math/Vector3",
+              r3fDocumentationUrl: "https://docs.pmnd.rs/react-three-fiber/api/events"
+            }
+          },
+          {
+            id: "camera-control",
+            startLine: 14,
+            endLine: 16,
+            startColumn: 1,
+            endColumn: 1,
+            tooltip: {
+              title: "カメラ操作の制御",
+              description: "ドラッグ中はOrbitControlsを無効化して、オブジェクト操作とカメラ操作の競合を防ぎます。useCameraControlコンテキストを使用して制御します。",
+              documentationUrl: "https://threejs.org/docs/#examples/en/controls/OrbitControls",
+              r3fDocumentationUrl: "https://docs.pmnd.rs/react-three-fiber/api/events#event-data"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'mouse-position-calculation',
+    name: "マウス位置の計算",
+    description: "スクリーン座標から3D空間の正規化座標への変換",
+    files: ["src/app/demos/interactions/dnd-scale/components/DndScaleInteractionWithControls.tsx"],
+    codeSections: [
+      {
+        title: "座標変換処理",
+        description: "マウスのスクリーン座標を3D空間で使用可能な正規化座標に変換",
+        fileName: "DndScaleInteractionWithControls.tsx",
+        code: `// マウス位置から正規化座標を計算
+const getMousePosition = useCallback((event: any) => {
+  const rect = gl.domElement.getBoundingClientRect()
+  const x = ((event.clientX - rect.left) / rect.width) * 2 - 1
+  const y = -((event.clientY - rect.top) / rect.height) * 2 + 1
+  return new Vector3(x, y, 0)
+}, [gl])
+
+// マウス移動時の処理
+const handlePointerMove = useCallback((event: any) => {
+  if (!dragState.isDragging || !dragState.object) return
+
+  event.stopPropagation()
+  
+  const currentMousePos = getMousePosition(event)
+  const deltaX = currentMousePos.x - dragState.startPosition.x
+  const deltaY = currentMousePos.y - dragState.startPosition.y
+  
+  // 距離に基づいてスケールを計算
+  const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY)
+  const scaleFactor = Math.max(0.1, 1 + distance * 2) // 最小スケール0.1
+  
+  // 均等にスケール変更
+  dragState.object.scale.setScalar(scaleFactor)
+}, [dragState, getMousePosition])`,
+        highlights: [
+          {
+            id: "coordinate-conversion",
+            startLine: 3,
+            endLine: 5,
+            startColumn: 1,
+            endColumn: 1,
+            tooltip: {
+              title: "座標変換",
+              description: "スクリーン座標（ピクセル）を正規化デバイス座標（-1から1の範囲）に変換します。この変換により、画面サイズに依存しない一貫した操作が可能になります。",
+              documentationUrl: "https://threejs.org/docs/#api/en/math/Vector3",
+              r3fDocumentationUrl: "https://docs.pmnd.rs/react-three-fiber/api/events#event-data"
+            }
+          },
+          {
+            id: "distance-calculation",
+            startLine: 17,
+            endLine: 18,
+            startColumn: 1,
+            endColumn: 1,
+            tooltip: {
+              title: "距離計算とスケール変更",
+              description: "開始位置からの距離を計算し、その距離に基づいてスケールファクターを決定します。Math.max()で最小スケールを制限し、オブジェクトが消失することを防ぎます。",
+              documentationUrl: "https://threejs.org/docs/#api/en/core/Object3D.scale",
+              r3fDocumentationUrl: "https://docs.pmnd.rs/react-three-fiber/api/objects#transformations"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'event-handling',
+    name: "イベントハンドリング",
+    description: "クリック、ホバー、ドラッグイベントの処理",
+    files: ["src/app/demos/interactions/dnd-scale/components/DndScaleInteractionWithControls.tsx"],
+    codeSections: [
+      {
+        title: "オブジェクトイベント処理",
+        description: "3Dオブジェクトのクリック、ホバー、ドラッグイベントの実装",
+        fileName: "DndScaleInteractionWithControls.tsx",
+        code: `// オブジェクトクリック時の処理
+const handleObjectClick = useCallback((event: any, objectRef: React.RefObject<Mesh>, objectName: string) => {
+  event.stopPropagation()
+  
+  if (!objectRef.current) return
+
+  if (dragState.isDragging && dragState.object === objectRef.current) {
+    // ドロップ処理
+    setDragState({
+      isDragging: false,
+      startPosition: new Vector3(),
+      startScale: new Vector3(),
+      object: null
+    })
+  } else {
+    // ドラッグ開始処理
+    const mousePos = getMousePosition(event)
+    setDragState({
+      isDragging: true,
+      startPosition: mousePos.clone(),
+      startScale: objectRef.current.scale.clone(),
+      object: objectRef.current
+    })
+  }
+}, [dragState, getMousePosition])
+
+// JSX内でのイベント設定
+<mesh
+  ref={boxRef}
+  position={[-3, 0, 0]}
+  castShadow
+  receiveShadow
+  onClick={(e) => handleObjectClick(e, boxRef, 'box')}
+  onPointerOver={() => setHoveredObject('box')}
+  onPointerOut={() => setHoveredObject(null)}
+  onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+>`,
+        highlights: [
+          {
+            id: "event-propagation",
+            startLine: 3,
+            endLine: 3,
+            startColumn: 1,
+            endColumn: 1,
+            tooltip: {
+              title: "イベント伝播の制御",
+              description: "event.stopPropagation()でイベントの伝播を停止し、背景要素への意図しないイベント発火を防ぎます。これにより、オブジェクト操作とカメラ操作の競合を回避できます。",
+              documentationUrl: "https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation",
+              r3fDocumentationUrl: "https://docs.pmnd.rs/react-three-fiber/api/events#event-data"
+            }
+          },
+          {
+            id: "conditional-events",
+            startLine: 34,
+            endLine: 34,
+            startColumn: 1,
+            endColumn: 1,
+            tooltip: {
+              title: "条件付きイベント設定",
+              description: "ドラッグ中のみonPointerMoveイベントを有効にすることで、不要な処理を削減し、パフォーマンスを向上させます。",
+              documentationUrl: "https://threejs.org/docs/#api/en/core/Object3D",
+              r3fDocumentationUrl: "https://docs.pmnd.rs/react-three-fiber/api/events"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'camera-control-context',
+    name: "カメラ制御コンテキスト",
+    description: "React Contextを使用したカメラ操作の制御",
+    files: ["src/app/demos/components/common/DemoLayoutWithControls.tsx"],
+    codeSections: [
+      {
+        title: "コンテキストによる状態管理",
+        description: "React Contextでカメラ操作の有効/無効を管理",
+        fileName: "DemoLayoutWithControls.tsx",
+        code: `// カメラ操作の制御用コンテキスト
+const CameraControlContext = createContext<{
+  enableControls: boolean
+  setEnableControls: (enable: boolean) => void
+}>({
+  enableControls: true,
+  setEnableControls: () => {}
+})
+
+export const useCameraControl = () => useContext(CameraControlContext)
+
+// プロバイダーでの状態管理
+const [enableControls, setEnableControls] = useState(true)
+
+return (
+  <CameraControlContext.Provider value={{ enableControls, setEnableControls }}>
+    {/* Canvas内でOrbitControlsの制御 */}
+    <OrbitControls 
+      enabled={enableControls}
+      enablePan={enableControls} 
+      enableZoom={enableControls} 
+      enableRotate={enableControls} 
+    />
+  </CameraControlContext.Provider>
+)`,
+        highlights: [
+          {
+            id: "context-definition",
+            startLine: 2,
+            endLine: 8,
+            startColumn: 1,
+            endColumn: 1,
+            tooltip: {
+              title: "Context定義",
+              description: "React Contextを使用してカメラ操作の状態を管理します。これにより、深い階層のコンポーネント間でpropsを渡すことなく状態を共有できます。",
+              documentationUrl: "https://react.dev/reference/react/createContext",
+              r3fDocumentationUrl: "https://docs.pmnd.rs/react-three-fiber/tutorials/basic-animations"
+            }
+          },
+          {
+            id: "orbit-controls",
+            startLine: 18,
+            endLine: 22,
+            startColumn: 1,
+            endColumn: 1,
+            tooltip: {
+              title: "OrbitControls制御",
+              description: "enabledプロパティでOrbitControls全体を制御し、個別のenable*プロパティで細かい操作を制御します。ドラッグ中は全ての操作を無効化します。",
+              documentationUrl: "https://threejs.org/docs/#examples/en/controls/OrbitControls",
+              r3fDocumentationUrl: "https://docs.pmnd.rs/react-three-fiber/api/objects#orbitcontrols"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/app/demos/config/interactions/dnd-scale/file-contents.ts
+++ b/src/app/demos/config/interactions/dnd-scale/file-contents.ts
@@ -1,0 +1,338 @@
+export const dndScaleFileContents: Record<string, string> = {
+  'src/app/demos/interactions/dnd-scale/page.tsx': `'use client'
+
+import { DemoLayoutWithControls } from '../../components/common/DemoLayoutWithControls'
+import { DndScaleInteractionWithControls } from './components/DndScaleInteractionWithControls'
+import { dndScaleFiles, dndScaleFeatures, dndScaleFileContents } from '../../config/interactions/dnd-scale'
+
+export default function DndScaleDemo() {
+  return (
+    <DemoLayoutWithControls 
+      title="Drag & Drop Scale Demo" 
+      description="ドラッグアンドドロップによるオブジェクトの寸法変更デモ"
+      files={dndScaleFiles}
+      features={dndScaleFeatures}
+      fileContents={dndScaleFileContents}
+      backLink="/demos/interactions"
+      backLinkText="インタラクション一覧に戻る"
+    >
+      <DndScaleInteractionWithControls />
+    </DemoLayoutWithControls>
+  )
+}`,
+
+  'src/app/demos/interactions/dnd-scale/components/DndScaleInteractionWithControls.tsx': `'use client'
+
+import { useRef, useState, useCallback, useEffect } from 'react'
+import { useThree } from '@react-three/fiber'
+import { Text } from '@react-three/drei'
+import { Mesh, Vector3 } from 'three'
+import { useCameraControl } from '../../../components/common/DemoLayoutWithControls'
+
+interface DragState {
+  isDragging: boolean
+  startPosition: Vector3
+  startScale: Vector3
+  object: Mesh | null
+}
+
+export function DndScaleInteractionWithControls() {
+  const boxRef = useRef<Mesh>(null)
+  const sphereRef = useRef<Mesh>(null)
+  const cylinderRef = useRef<Mesh>(null)
+  
+  const [dragState, setDragState] = useState<DragState>({
+    isDragging: false,
+    startPosition: new Vector3(),
+    startScale: new Vector3(),
+    object: null
+  })
+  
+  const [hoveredObject, setHoveredObject] = useState<string | null>(null)
+  const { gl } = useThree()
+  const { setEnableControls } = useCameraControl()
+
+  // ドラッグ状態が変わったときにカメラ操作を制御
+  useEffect(() => {
+    setEnableControls(!dragState.isDragging)
+  }, [dragState.isDragging, setEnableControls])
+
+  // マウス位置から正規化座標を計算
+  const getMousePosition = useCallback((event: any) => {
+    const rect = gl.domElement.getBoundingClientRect()
+    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1
+    const y = -((event.clientY - rect.top) / rect.height) * 2 + 1
+    return new Vector3(x, y, 0)
+  }, [gl])
+
+  // オブジェクトクリック時の処理
+  const handleObjectClick = useCallback((event: any, objectRef: React.RefObject<Mesh>, objectName: string) => {
+    event.stopPropagation()
+    
+    if (!objectRef.current) return
+
+    if (dragState.isDragging && dragState.object === objectRef.current) {
+      // ドロップ処理
+      setDragState({
+        isDragging: false,
+        startPosition: new Vector3(),
+        startScale: new Vector3(),
+        object: null
+      })
+    } else {
+      // ドラッグ開始処理
+      const mousePos = getMousePosition(event)
+      setDragState({
+        isDragging: true,
+        startPosition: mousePos.clone(),
+        startScale: objectRef.current.scale.clone(),
+        object: objectRef.current
+      })
+    }
+  }, [dragState, getMousePosition])
+
+  // マウス移動時の処理
+  const handlePointerMove = useCallback((event: any) => {
+    if (!dragState.isDragging || !dragState.object) return
+
+    event.stopPropagation()
+    
+    const currentMousePos = getMousePosition(event)
+    const deltaX = currentMousePos.x - dragState.startPosition.x
+    const deltaY = currentMousePos.y - dragState.startPosition.y
+    
+    // 距離に基づいてスケールを計算
+    const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY)
+    const scaleFactor = Math.max(0.1, 1 + distance * 2) // 最小スケール0.1
+    
+    // 均等にスケール変更
+    dragState.object.scale.setScalar(scaleFactor)
+  }, [dragState, getMousePosition])
+
+  // 背景クリック時の処理
+  const handleBackgroundClick = useCallback((event: any) => {
+    if (dragState.isDragging) {
+      // ドラッグモード中は背景クリックでドロップ
+      setDragState({
+        isDragging: false,
+        startPosition: new Vector3(),
+        startScale: new Vector3(),
+        object: null
+      })
+    }
+  }, [dragState.isDragging])
+
+  return (
+    <group>
+      {/* 背景用の大きな平面（ドラッグモード時のドロップ検出用） */}
+      <mesh
+        position={[0, 0, -5]}
+        onClick={handleBackgroundClick}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <planeGeometry args={[100, 100]} />
+        <meshBasicMaterial transparent opacity={0} />
+      </mesh>
+
+      {/* 立方体 */}
+      <mesh
+        ref={boxRef}
+        position={[-3, 0, 0]}
+        castShadow
+        receiveShadow
+        onClick={(e) => handleObjectClick(e, boxRef, 'box')}
+        onPointerOver={() => setHoveredObject('box')}
+        onPointerOut={() => setHoveredObject(null)}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial 
+          color={hoveredObject === 'box' ? '#ff8888' : '#ff6b6b'}
+          emissive={dragState.object === boxRef.current ? '#440000' : '#000000'}
+        />
+      </mesh>
+
+      {/* 球体 */}
+      <mesh
+        ref={sphereRef}
+        position={[0, 0, 0]}
+        castShadow
+        receiveShadow
+        onClick={(e) => handleObjectClick(e, sphereRef, 'sphere')}
+        onPointerOver={() => setHoveredObject('sphere')}
+        onPointerOut={() => setHoveredObject(null)}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <sphereGeometry args={[0.8, 32, 32]} />
+        <meshStandardMaterial 
+          color={hoveredObject === 'sphere' ? '#88ff88' : '#6bff6b'}
+          emissive={dragState.object === sphereRef.current ? '#004400' : '#000000'}
+        />
+      </mesh>
+
+      {/* 円柱 */}
+      <mesh
+        ref={cylinderRef}
+        position={[3, 0, 0]}
+        castShadow
+        receiveShadow
+        onClick={(e) => handleObjectClick(e, cylinderRef, 'cylinder')}
+        onPointerOver={() => setHoveredObject('cylinder')}
+        onPointerOut={() => setHoveredObject(null)}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <cylinderGeometry args={[0.6, 0.6, 1.5, 32]} />
+        <meshStandardMaterial 
+          color={hoveredObject === 'cylinder' ? '#8888ff' : '#6b6bff'}
+          emissive={dragState.object === cylinderRef.current ? '#000044' : '#000000'}
+        />
+      </mesh>
+
+      {/* 説明テキスト */}
+      <Text position={[0, -3, 0]} fontSize={0.4} color="white" anchorX="center">
+        {dragState.isDragging 
+          ? "ドラッグして寸法変更 | クリックでドロップ"
+          : "オブジェクトをクリックしてドラッグモード開始"
+        }
+      </Text>
+
+      {/* 操作説明 */}
+      <Text position={[0, -4, 0]} fontSize={0.25} color="gray" anchorX="center">
+        クリック → ドラッグで寸法変更 → クリックで確定
+      </Text>
+
+      {/* ドラッグ状態インジケーター */}
+      {dragState.isDragging && (
+        <Text position={[0, 3, 0]} fontSize={0.3} color="yellow" anchorX="center">
+          🎯 ドラッグモード中 (カメラ操作無効)
+        </Text>
+      )}
+    </group>
+  )
+}`,
+
+  'src/app/demos/components/common/DemoLayoutWithControls.tsx': `'use client'
+
+import { useState, createContext, useContext } from 'react'
+import Link from 'next/link'
+import { Canvas } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
+import { Lighting } from './Lighting'
+import { FileExplorer, FeatureSelector, CodeViewer } from '../file-system'
+import { FileNode, FeatureFile } from '../../config/types'
+
+// カメラ操作の制御用コンテキスト
+const CameraControlContext = createContext<{
+  enableControls: boolean
+  setEnableControls: (enable: boolean) => void
+}>({
+  enableControls: true,
+  setEnableControls: () => {}
+})
+
+export const useCameraControl = () => useContext(CameraControlContext)
+
+interface DemoLayoutWithControlsProps {
+  title: string
+  description: string
+  files: FileNode[]
+  features: FeatureFile[]
+  fileContents: Record<string, string>
+  children: React.ReactNode
+  backLink?: string
+  backLinkText?: string
+}
+
+export function DemoLayoutWithControls({ 
+  title, 
+  description, 
+  files, 
+  features, 
+  fileContents, 
+  children,
+  backLink = "/demos",
+  backLinkText = "デモ一覧に戻る"
+}: DemoLayoutWithControlsProps) {
+  const [selectedFeature, setSelectedFeature] = useState<FeatureFile | null>(null)
+  const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  const [enableControls, setEnableControls] = useState(true)
+
+  return (
+    <CameraControlContext.Provider value={{ enableControls, setEnableControls }}>
+      <div className="min-h-screen bg-gray-900 text-white">
+        <div className="bg-gray-900 min-h-full">
+          <div className="container mx-auto px-4 py-8">
+            {/* ナビゲーション */}
+            <div className="mb-6">
+              <Link 
+                href={backLink}
+                className="inline-flex items-center text-blue-400 hover:text-blue-300 transition-colors duration-200 text-sm"
+              >
+                <svg className="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+                {backLinkText}
+              </Link>
+            </div>
+
+            <div className="mb-8">
+              <h1 className="text-3xl font-bold mb-2">{title}</h1>
+              <p className="text-gray-300">{description}</p>
+            </div>
+            
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 min-h-[calc(100vh-200px)]">
+              {/* 3D Canvas */}
+              <div className="bg-gray-800 rounded-lg overflow-hidden min-h-[500px]">
+                <Canvas
+                  camera={{ 
+                    position: [3, 3, 3],
+                    fov: 60
+                  }}
+                  shadows
+                  className="w-full h-full"
+                >
+                  <Lighting />
+                  {children}
+                  
+                  <OrbitControls 
+                    enabled={enableControls}
+                    enablePan={enableControls} 
+                    enableZoom={enableControls} 
+                    enableRotate={enableControls} 
+                  />
+                  
+                  <gridHelper args={[10, 10]} />
+                </Canvas>
+              </div>
+              
+              {/* Code Panel */}
+              <div className="bg-gray-800 rounded-lg p-4 flex flex-col min-h-[500px]">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                  <FileExplorer 
+                    files={files} 
+                    selectedFile={selectedFile}
+                    onFileSelect={setSelectedFile}
+                  />
+                  <FeatureSelector 
+                    features={features} 
+                    selectedFeature={selectedFeature}
+                    onFeatureSelect={setSelectedFeature}
+                  />
+                </div>
+                <div className="flex-1">
+                  <CodeViewer 
+                    features={features} 
+                    fileContents={fileContents} 
+                    selectedFeature={selectedFeature}
+                    selectedFile={selectedFile}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </CameraControlContext.Provider>
+  )
+}`
+}

--- a/src/app/demos/config/interactions/dnd-scale/files.ts
+++ b/src/app/demos/config/interactions/dnd-scale/files.ts
@@ -1,0 +1,57 @@
+import { FileNode } from '../../types'
+
+export const dndScaleFiles: FileNode[] = [
+  {
+    name: 'src',
+    type: 'folder',
+    children: [
+      {
+        name: 'app',
+        type: 'folder',
+        children: [
+          {
+            name: 'demos',
+            type: 'folder',
+            children: [
+              {
+                name: 'interactions',
+                type: 'folder',
+                children: [
+                  {
+                    name: 'dnd-scale',
+                    type: 'folder',
+                    children: [
+                      { name: 'page.tsx', type: 'file' },
+                      {
+                        name: 'components',
+                        type: 'folder',
+                        children: [
+                          { name: 'DndScaleInteractionWithControls.tsx', type: 'file' }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                name: 'components',
+                type: 'folder',
+                children: [
+                  {
+                    name: 'common',
+                    type: 'folder',
+                    children: [
+                      { name: 'DemoLayoutWithControls.tsx', type: 'file' },
+                      { name: 'Lighting.tsx', type: 'file' },
+                      { name: 'index.ts', type: 'file' }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/app/demos/config/interactions/dnd-scale/index.ts
+++ b/src/app/demos/config/interactions/dnd-scale/index.ts
@@ -1,0 +1,3 @@
+export { dndScaleFiles } from './files'
+export { dndScaleFeatures } from './features'
+export { dndScaleFileContents } from './file-contents'

--- a/src/app/demos/interactions/dnd-scale/components/DndScaleInteraction.tsx
+++ b/src/app/demos/interactions/dnd-scale/components/DndScaleInteraction.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { useRef, useState, useCallback } from 'react'
+import { useThree } from '@react-three/fiber'
+import { Text } from '@react-three/drei'
+import { Mesh, Vector3 } from 'three'
+
+interface DragState {
+  isDragging: boolean
+  startPosition: Vector3
+  startScale: Vector3
+  object: Mesh | null
+}
+
+export function DndScaleInteraction() {
+  const boxRef = useRef<Mesh>(null)
+  const sphereRef = useRef<Mesh>(null)
+  const cylinderRef = useRef<Mesh>(null)
+  
+  const [dragState, setDragState] = useState<DragState>({
+    isDragging: false,
+    startPosition: new Vector3(),
+    startScale: new Vector3(),
+    object: null
+  })
+  
+  const [hoveredObject, setHoveredObject] = useState<string | null>(null)
+  const { gl } = useThree()
+
+  // マウス位置から正規化座標を計算
+  const getMousePosition = useCallback((event: any) => {
+    const rect = gl.domElement.getBoundingClientRect()
+    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1
+    const y = -((event.clientY - rect.top) / rect.height) * 2 + 1
+    return new Vector3(x, y, 0)
+  }, [gl])
+
+  // オブジェクトクリック時の処理
+  const handleObjectClick = useCallback((event: any, objectRef: React.RefObject<Mesh>, objectName: string) => {
+    event.stopPropagation()
+    
+    if (!objectRef.current) return
+
+    if (dragState.isDragging && dragState.object === objectRef.current) {
+      // ドロップ処理
+      setDragState({
+        isDragging: false,
+        startPosition: new Vector3(),
+        startScale: new Vector3(),
+        object: null
+      })
+    } else {
+      // ドラッグ開始処理
+      const mousePos = getMousePosition(event)
+      setDragState({
+        isDragging: true,
+        startPosition: mousePos.clone(),
+        startScale: objectRef.current.scale.clone(),
+        object: objectRef.current
+      })
+    }
+  }, [dragState, getMousePosition])
+
+  // マウス移動時の処理
+  const handlePointerMove = useCallback((event: any) => {
+    if (!dragState.isDragging || !dragState.object) return
+
+    event.stopPropagation()
+    
+    const currentMousePos = getMousePosition(event)
+    const deltaX = currentMousePos.x - dragState.startPosition.x
+    const deltaY = currentMousePos.y - dragState.startPosition.y
+    
+    // 距離に基づいてスケールを計算
+    const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY)
+    const scaleFactor = Math.max(0.1, 1 + distance * 2) // 最小スケール0.1
+    
+    // 均等にスケール変更
+    dragState.object.scale.setScalar(scaleFactor)
+  }, [dragState, getMousePosition])
+
+  // 背景クリック時の処理（ドラッグモード時はカメラ操作を無効化）
+  const handleBackgroundClick = useCallback((event: any) => {
+    if (dragState.isDragging) {
+      // ドラッグモード中は背景クリックでドロップ
+      setDragState({
+        isDragging: false,
+        startPosition: new Vector3(),
+        startScale: new Vector3(),
+        object: null
+      })
+    }
+  }, [dragState.isDragging])
+
+  return (
+    <group>
+      {/* 背景用の大きな平面（ドラッグモード時のドロップ検出用） */}
+      <mesh
+        position={[0, 0, -5]}
+        onClick={handleBackgroundClick}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <planeGeometry args={[100, 100]} />
+        <meshBasicMaterial transparent opacity={0} />
+      </mesh>
+
+      {/* 立方体 */}
+      <mesh
+        ref={boxRef}
+        position={[-3, 0, 0]}
+        castShadow
+        receiveShadow
+        onClick={(e) => handleObjectClick(e, boxRef, 'box')}
+        onPointerOver={() => setHoveredObject('box')}
+        onPointerOut={() => setHoveredObject(null)}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial 
+          color={hoveredObject === 'box' ? '#ff8888' : '#ff6b6b'}
+          emissive={dragState.object === boxRef.current ? '#440000' : '#000000'}
+        />
+      </mesh>
+
+      {/* 球体 */}
+      <mesh
+        ref={sphereRef}
+        position={[0, 0, 0]}
+        castShadow
+        receiveShadow
+        onClick={(e) => handleObjectClick(e, sphereRef, 'sphere')}
+        onPointerOver={() => setHoveredObject('sphere')}
+        onPointerOut={() => setHoveredObject(null)}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <sphereGeometry args={[0.8, 32, 32]} />
+        <meshStandardMaterial 
+          color={hoveredObject === 'sphere' ? '#88ff88' : '#6bff6b'}
+          emissive={dragState.object === sphereRef.current ? '#004400' : '#000000'}
+        />
+      </mesh>
+
+      {/* 円柱 */}
+      <mesh
+        ref={cylinderRef}
+        position={[3, 0, 0]}
+        castShadow
+        receiveShadow
+        onClick={(e) => handleObjectClick(e, cylinderRef, 'cylinder')}
+        onPointerOver={() => setHoveredObject('cylinder')}
+        onPointerOut={() => setHoveredObject(null)}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <cylinderGeometry args={[0.6, 0.6, 1.5, 32]} />
+        <meshStandardMaterial 
+          color={hoveredObject === 'cylinder' ? '#8888ff' : '#6b6bff'}
+          emissive={dragState.object === cylinderRef.current ? '#000044' : '#000000'}
+        />
+      </mesh>
+
+      {/* 説明テキスト */}
+      <Text position={[0, -3, 0]} fontSize={0.4} color="white" anchorX="center">
+        {dragState.isDragging 
+          ? "ドラッグして寸法変更 | クリックでドロップ"
+          : "オブジェクトをクリックしてドラッグモード開始"
+        }
+      </Text>
+
+      {/* 操作説明 */}
+      <Text position={[0, -4, 0]} fontSize={0.25} color="gray" anchorX="center">
+        クリック → ドラッグで寸法変更 → クリックで確定
+      </Text>
+
+      {/* ドラッグ状態インジケーター */}
+      {dragState.isDragging && (
+        <Text position={[0, 3, 0]} fontSize={0.3} color="yellow" anchorX="center">
+          🎯 ドラッグモード中
+        </Text>
+      )}
+    </group>
+  )
+}

--- a/src/app/demos/interactions/dnd-scale/components/DndScaleInteractionWithControls.tsx
+++ b/src/app/demos/interactions/dnd-scale/components/DndScaleInteractionWithControls.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useRef, useState, useCallback, useEffect } from 'react'
+import { useThree } from '@react-three/fiber'
+import { Text } from '@react-three/drei'
+import { Mesh, Vector3 } from 'three'
+import { useCameraControl } from '../../../components/common/DemoLayoutWithControls'
+
+interface DragState {
+  isDragging: boolean
+  startPosition: Vector3
+  startScale: Vector3
+  object: Mesh | null
+}
+
+export function DndScaleInteractionWithControls() {
+  const boxRef = useRef<Mesh>(null)
+  const sphereRef = useRef<Mesh>(null)
+  const cylinderRef = useRef<Mesh>(null)
+  
+  const [dragState, setDragState] = useState<DragState>({
+    isDragging: false,
+    startPosition: new Vector3(),
+    startScale: new Vector3(),
+    object: null
+  })
+  
+  const [hoveredObject, setHoveredObject] = useState<string | null>(null)
+  const { gl } = useThree()
+  const { setEnableControls } = useCameraControl()
+
+  // ドラッグ状態が変わったときにカメラ操作を制御
+  useEffect(() => {
+    setEnableControls(!dragState.isDragging)
+  }, [dragState.isDragging, setEnableControls])
+
+  // マウス位置から正規化座標を計算
+  const getMousePosition = useCallback((event: any) => {
+    const rect = gl.domElement.getBoundingClientRect()
+    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1
+    const y = -((event.clientY - rect.top) / rect.height) * 2 + 1
+    return new Vector3(x, y, 0)
+  }, [gl])
+
+  // オブジェクトクリック時の処理
+  const handleObjectClick = useCallback((event: any, objectRef: React.RefObject<Mesh>, objectName: string) => {
+    event.stopPropagation()
+    
+    if (!objectRef.current) return
+
+    if (dragState.isDragging && dragState.object === objectRef.current) {
+      // ドロップ処理
+      setDragState({
+        isDragging: false,
+        startPosition: new Vector3(),
+        startScale: new Vector3(),
+        object: null
+      })
+    } else {
+      // ドラッグ開始処理
+      const mousePos = getMousePosition(event)
+      setDragState({
+        isDragging: true,
+        startPosition: mousePos.clone(),
+        startScale: objectRef.current.scale.clone(),
+        object: objectRef.current
+      })
+    }
+  }, [dragState, getMousePosition])
+
+  // マウス移動時の処理
+  const handlePointerMove = useCallback((event: any) => {
+    if (!dragState.isDragging || !dragState.object) return
+
+    event.stopPropagation()
+    
+    const currentMousePos = getMousePosition(event)
+    const deltaX = currentMousePos.x - dragState.startPosition.x
+    const deltaY = currentMousePos.y - dragState.startPosition.y
+    
+    // 距離に基づいてスケールを計算
+    const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY)
+    const scaleFactor = Math.max(0.1, 1 + distance * 2) // 最小スケール0.1
+    
+    // 均等にスケール変更
+    dragState.object.scale.setScalar(scaleFactor)
+  }, [dragState, getMousePosition])
+
+  // 背景クリック時の処理
+  const handleBackgroundClick = useCallback((event: any) => {
+    if (dragState.isDragging) {
+      // ドラッグモード中は背景クリックでドロップ
+      setDragState({
+        isDragging: false,
+        startPosition: new Vector3(),
+        startScale: new Vector3(),
+        object: null
+      })
+    }
+  }, [dragState.isDragging])
+
+  return (
+    <group>
+      {/* 背景用の大きな平面（ドラッグモード時のドロップ検出用） */}
+      <mesh
+        position={[0, 0, -5]}
+        onClick={handleBackgroundClick}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <planeGeometry args={[100, 100]} />
+        <meshBasicMaterial transparent opacity={0} />
+      </mesh>
+
+      {/* 立方体 */}
+      <mesh
+        ref={boxRef}
+        position={[-3, 0, 0]}
+        castShadow
+        receiveShadow
+        onClick={(e) => handleObjectClick(e, boxRef, 'box')}
+        onPointerOver={() => setHoveredObject('box')}
+        onPointerOut={() => setHoveredObject(null)}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial 
+          color={hoveredObject === 'box' ? '#ff8888' : '#ff6b6b'}
+          emissive={dragState.object === boxRef.current ? '#440000' : '#000000'}
+        />
+      </mesh>
+
+      {/* 球体 */}
+      <mesh
+        ref={sphereRef}
+        position={[0, 0, 0]}
+        castShadow
+        receiveShadow
+        onClick={(e) => handleObjectClick(e, sphereRef, 'sphere')}
+        onPointerOver={() => setHoveredObject('sphere')}
+        onPointerOut={() => setHoveredObject(null)}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <sphereGeometry args={[0.8, 32, 32]} />
+        <meshStandardMaterial 
+          color={hoveredObject === 'sphere' ? '#88ff88' : '#6bff6b'}
+          emissive={dragState.object === sphereRef.current ? '#004400' : '#000000'}
+        />
+      </mesh>
+
+      {/* 円柱 */}
+      <mesh
+        ref={cylinderRef}
+        position={[3, 0, 0]}
+        castShadow
+        receiveShadow
+        onClick={(e) => handleObjectClick(e, cylinderRef, 'cylinder')}
+        onPointerOver={() => setHoveredObject('cylinder')}
+        onPointerOut={() => setHoveredObject(null)}
+        onPointerMove={dragState.isDragging ? handlePointerMove : undefined}
+      >
+        <cylinderGeometry args={[0.6, 0.6, 1.5, 32]} />
+        <meshStandardMaterial 
+          color={hoveredObject === 'cylinder' ? '#8888ff' : '#6b6bff'}
+          emissive={dragState.object === cylinderRef.current ? '#000044' : '#000000'}
+        />
+      </mesh>
+
+      {/* 説明テキスト */}
+      <Text position={[0, -3, 0]} fontSize={0.4} color="white" anchorX="center">
+        {dragState.isDragging 
+          ? "ドラッグして寸法変更 | クリックでドロップ"
+          : "オブジェクトをクリックしてドラッグモード開始"
+        }
+      </Text>
+
+      {/* 操作説明 */}
+      <Text position={[0, -4, 0]} fontSize={0.25} color="gray" anchorX="center">
+        クリック → ドラッグで寸法変更 → クリックで確定
+      </Text>
+
+      {/* ドラッグ状態インジケーター */}
+      {dragState.isDragging && (
+        <Text position={[0, 3, 0]} fontSize={0.3} color="yellow" anchorX="center">
+          🎯 ドラッグモード中 (カメラ操作無効)
+        </Text>
+      )}
+    </group>
+  )
+}

--- a/src/app/demos/interactions/dnd-scale/page.tsx
+++ b/src/app/demos/interactions/dnd-scale/page.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { DemoLayoutWithControls } from '../../components/common/DemoLayoutWithControls'
+import { DndScaleInteractionWithControls } from './components/DndScaleInteractionWithControls'
+import { dndScaleFiles, dndScaleFeatures, dndScaleFileContents } from '../../config/interactions/dnd-scale'
+
+export default function DndScaleDemo() {
+  return (
+    <DemoLayoutWithControls 
+      title="Drag & Drop Scale Demo" 
+      description="ドラッグアンドドロップによるオブジェクトの寸法変更デモ"
+      files={dndScaleFiles}
+      features={dndScaleFeatures}
+      fileContents={dndScaleFileContents}
+      backLink="/demos/interactions"
+      backLinkText="インタラクション一覧に戻る"
+    >
+      <DndScaleInteractionWithControls />
+    </DemoLayoutWithControls>
+  )
+}


### PR DESCRIPTION
## 概要
### DnDによるスケール変更デモ画面の実装
React Three Fiberを使用した3Dオブジェクトのドラッグアンドドロップによるスケール変更機能のデモ画面を実装した。

## 変更内容

### 新規追加ファイル

#### メインコンポーネント
- `src/app/demos/interactions/dnd-scale/page.tsx`
  - デモページのエントリーポイント
  - DemoLayoutWithControlsとの統合

- `src/app/demos/interactions/dnd-scale/components/DndScaleInteraction.tsx`
  - 基本的なスケール変更インタラクション機能
  - 3種類のオブジェクト（立方体、球体、円柱）
  - ドラッグ状態管理とマウスイベント処理

- `src/app/demos/interactions/dnd-scale/components/DndScaleInteractionWithControls.tsx`
  - カメラ操作制御機能を統合したバージョン
  - useCameraControlフックとの連携

#### 設定ファイル群
- `src/app/demos/config/interactions/dnd-scale/files.ts`
  - ファイル構成の定義
- `src/app/demos/config/interactions/dnd-scale/features.ts`
  - 機能説明とコード解説
- `src/app/demos/config/interactions/dnd-scale/file-contents.ts`
  - 各ファイルのコード内容
- `src/app/demos/config/interactions/dnd-scale/index.ts`
  - 設定のエクスポート

### 既存ファイルの拡張

#### 共通コンポーネント
- `src/app/demos/components/common/DemoLayoutWithControls.tsx`
  - CameraControlContextの追加
  - useCameraControlフックの実装
  - OrbitControlsの動的制御機能

- `src/app/demos/components/common/index.ts`
  - DemoLayoutWithControlsのエクスポート追加

## 実装のポイント

### 1. ドラッグ状態管理
```typescript
interface DragState {
  isDragging: boolean
  startPosition: Vector3
  startScale: Vector3
  object: Mesh | null
}
```

### 2. スケール計算ロジック
```typescript
const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY)
const scaleFactor = Math.max(0.1, 1 + distance * 2)
dragState.object.scale.setScalar(scaleFactor)
```

### 3. カメラ操作制御
```typescript
const { setEnableControls } = useCameraControl()

useEffect(() => {
  setEnableControls(!dragState.isDragging)
}, [dragState.isDragging, setEnableControls])
```

### 4. イベント処理の最適化
- `useCallback`を使用した関数メモ化
- `event.stopPropagation()`による適切なイベント制御
- 条件付きイベントハンドラーの設定

## 機能詳細

### インタラクション仕様
- **開始**: オブジェクトクリックでドラッグモード開始
- **変更**: マウス移動距離に基づくリアルタイムスケール変更
- **終了**: 背景クリックまたはオブジェクト再クリックで確定
- **制約**: 最小スケール0.1倍の制限

### 視覚フィードバック
- ホバー時の色変化（明度アップ）
- ドラッグ中のエミッシブ効果
- 動的ステータステキスト表示
- ドラッグモードインジケーター

### UX改善
- カメラ操作の自動無効化/有効化
- 直感的な操作説明の表示
- 明確な状態遷移の可視化

## テスト方法

### 基本動作確認
1. `/demos/interactions/dnd-scale`にアクセス
2. 3つのオブジェクトが正しく表示されることを確認
3. 各オブジェクトをクリックしてドラッグモードに入る
4. マウス移動でスケールが変更されることを確認
5. 背景クリックまたは再クリックで終了することを確認

### カメラ操作制御確認
1. 通常時にOrbitControlsが機能することを確認
2. ドラッグモード中にカメラ操作が無効化されることを確認
3. ドラッグ終了後にカメラ操作が復活することを確認

### ファイルシステム統合確認
1. ファイルエクスプローラーでファイル選択が機能することを確認
2. 機能セレクターで適切な説明が表示されることを確認
3. コードビューアーで正しいコードが表示されることを確認

## 影響範囲
- 新規機能追加のため既存機能への影響なし
- 共通コンポーネントの拡張は後方互換性を維持
- インタラクションデモ一覧への追加が必要

## スクリーンショット / gif
![github-pr-feature:frontend:interaction-demo-dnd-scale](https://github.com/user-attachments/assets/48acfff5-63ac-4c9b-8bf8-7a45c11eb881)


## 今後の拡張予定
- モバイルタッチ操作対応
- 軸別スケール変更機能
- アニメーション付きスケール変更
- 数値入力によるスケール指定

## 関連リンク
- デモページ: `/demos/interactions/dnd-scale`
- 既存DnD機能: `/demos/interactions/dnd-position`
